### PR TITLE
feat(wishlist): add JWT-based wishlist APIs with clean architecture

### DIFF
--- a/src/main/java/com/learnease/server/controller/WishlistController.java
+++ b/src/main/java/com/learnease/server/controller/WishlistController.java
@@ -1,0 +1,80 @@
+package com.learnease.server.controller;
+
+
+import com.learnease.server.dto.ApiResponse;
+import com.learnease.server.dto.JWTDTO;
+import com.learnease.server.dto.wishlist.WishlistResponseDto;
+import com.learnease.server.model.Wishlist;
+import com.learnease.server.service.WishlistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/wishlist")
+@Tag(name = "Wishlist", description = "APIs for managing student wishlist")
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    @Operation(summary = "Add course to wishlist")
+    @PostMapping("/{courseId}")
+    public ResponseEntity<ApiResponse> addToWishlist(
+            @PathVariable UUID courseId,
+            @AuthenticationPrincipal JWTDTO jwtdto
+    ) {
+        wishlistService.addToWishlist(jwtdto.getUserId(), courseId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ApiResponse(true, "Course added to wishlist"));
+    }
+
+
+    @Operation(summary = "Remove course from wishlist")
+    @DeleteMapping("/{courseId}")
+    public ResponseEntity<ApiResponse> removeFromWishlist(
+            @PathVariable UUID courseId,
+            @AuthenticationPrincipal JWTDTO jwtdto
+    ) {
+        wishlistService.removeFromWishlist(jwtdto.getUserId(), courseId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ApiResponse(true, "Course removed from wishlist"));
+    }
+
+    @Operation(summary = "Get wishlist")
+    @GetMapping
+    public ResponseEntity<List<WishlistResponseDto>> getWishlist(
+            @AuthenticationPrincipal JWTDTO jwtdto
+    ) {
+        List<WishlistResponseDto> wishlist =
+                wishlistService.getWishlist(jwtdto.getUserId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(wishlist);
+    }
+
+    @Operation(summary = "Get wishlist count")
+    @GetMapping("/count")
+    public ResponseEntity<Long> getWishlistCount(
+            @AuthenticationPrincipal JWTDTO jwtdto
+    ) {
+        long count =
+                wishlistService.getWishlistCount(jwtdto.getUserId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(count);
+    }
+}

--- a/src/main/java/com/learnease/server/dto/wishlist/WishlistResponseDto.java
+++ b/src/main/java/com/learnease/server/dto/wishlist/WishlistResponseDto.java
@@ -1,0 +1,21 @@
+package com.learnease.server.dto.wishlist;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WishlistResponseDto {
+
+    private UUID courseId;
+    private String title;
+    private String thumbnail;
+    private double fees;
+    private int discount;
+}

--- a/src/main/java/com/learnease/server/model/Wishlist.java
+++ b/src/main/java/com/learnease/server/model/Wishlist.java
@@ -1,0 +1,33 @@
+package com.learnease.server.model;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+        name = "wishlist",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_wishlist_student_course",
+                        columnNames = {"student_id", "course_id"}
+                )
+        }
+)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Wishlist extends BaseEntity{
+
+    @ManyToOne(fetch = FetchType.LAZY , optional = false)
+    @JoinColumn(name = "student_id" , nullable = false)
+    private Student student;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+}

--- a/src/main/java/com/learnease/server/repository/WishlistRepository.java
+++ b/src/main/java/com/learnease/server/repository/WishlistRepository.java
@@ -1,0 +1,20 @@
+package com.learnease.server.repository;
+
+import com.learnease.server.model.Course;
+import com.learnease.server.model.Student;
+import com.learnease.server.model.Wishlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface WishlistRepository extends JpaRepository<Wishlist , UUID> {
+
+    boolean existsByStudentAndCourse(Student student, Course course);
+
+    List<Wishlist> findByStudent(Student student);
+
+    long countByStudent(Student student);
+
+    void deleteByStudentAndCourse(Student student, Course course);
+}

--- a/src/main/java/com/learnease/server/service/WishlistService.java
+++ b/src/main/java/com/learnease/server/service/WishlistService.java
@@ -1,0 +1,16 @@
+package com.learnease.server.service;
+
+import com.learnease.server.dto.wishlist.WishlistResponseDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface WishlistService {
+    void addToWishlist(UUID authId, UUID courseId);
+
+    void removeFromWishlist(UUID authId, UUID courseId);
+
+    List<WishlistResponseDto> getWishlist(UUID authId);
+
+    long getWishlistCount(UUID authId);
+}

--- a/src/main/java/com/learnease/server/service/impl/WishlistServiceImpl.java
+++ b/src/main/java/com/learnease/server/service/impl/WishlistServiceImpl.java
@@ -1,0 +1,86 @@
+package com.learnease.server.service.impl;
+
+import com.learnease.server.dto.wishlist.WishlistResponseDto;
+import com.learnease.server.exception.custom_exception.CourseNotFoundException;
+import com.learnease.server.exception.custom_exception.UserNotFoundException;
+import com.learnease.server.model.Course;
+import com.learnease.server.model.Student;
+import com.learnease.server.model.Wishlist;
+import com.learnease.server.repository.CourseRepository;
+import com.learnease.server.repository.StudentRepository;
+import com.learnease.server.repository.WishlistRepository;
+import com.learnease.server.service.WishlistService;
+import com.learnease.server.util.mappers.WishlistMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WishlistServiceImpl implements WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+    private final StudentRepository studentRepository;
+    private final CourseRepository courseRepository;
+    private final WishlistMapper wishlistMapper;
+
+    private Student getStudentFromAuthId(UUID authId) {
+        return studentRepository.findByUserDetails_UserAuth_Id(authId)
+                .orElseThrow(() -> new UserNotFoundException("Student not found for authenticated user"));
+    }
+
+    @Override
+    public void addToWishlist(UUID authId, UUID courseId) {
+        Student student = getStudentFromAuthId(authId);
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(()-> new CourseNotFoundException(courseId));
+
+        boolean alreadyExists =
+                wishlistRepository.existsByStudentAndCourse(student , course);
+
+        //// Idempotent
+        if (alreadyExists) {
+            return;
+        }
+
+        Wishlist wishlist = new Wishlist();
+        wishlist.setStudent(student);
+        wishlist.setCourse(course);
+
+        wishlistRepository.save(wishlist);
+    }
+
+    @Override
+    public void removeFromWishlist(UUID authId, UUID courseId) {
+
+        Student student = getStudentFromAuthId(authId);
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        // Idempotent remove
+        wishlistRepository.deleteByStudentAndCourse(student, course);
+    }
+
+    @Override
+    public List<WishlistResponseDto> getWishlist(UUID authId) {
+
+        Student student = getStudentFromAuthId(authId);
+        return wishlistRepository.findByStudent(student)
+                .stream()
+                .map(wishlistMapper::toResponseDto)
+                .toList();
+    }
+
+    @Override
+    public long getWishlistCount(UUID authId) {
+
+        Student student = getStudentFromAuthId(authId);
+        return wishlistRepository.countByStudent(student);
+    }
+}

--- a/src/main/java/com/learnease/server/util/mappers/WishlistMapper.java
+++ b/src/main/java/com/learnease/server/util/mappers/WishlistMapper.java
@@ -1,0 +1,20 @@
+package com.learnease.server.util.mappers;
+
+import com.learnease.server.dto.wishlist.WishlistResponseDto;
+import com.learnease.server.model.Wishlist;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WishlistMapper {
+
+    public WishlistResponseDto toResponseDto(Wishlist wishlist) {
+
+        return new WishlistResponseDto(
+                wishlist.getCourse().getId(),
+                wishlist.getCourse().getTitle(),
+                wishlist.getCourse().getThumbnail(),
+                wishlist.getCourse().getFees(),
+                wishlist.getCourse().getDiscount()
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a production-ready Wishlist feature on the backend.

### Key highlights
- Added Wishlist domain model with unique (student, course) constraint
- Implemented idempotent add/remove wishlist operations
- Resolved student identity using JWT (authId-based lookup)
- Introduced mapper + DTO to avoid entity exposure
- Exposed clean, documented REST APIs for wishlist management
- Added wishlist count endpoint for Navbar integration

### API Endpoints
- POST    /api/v1/wishlist/{courseId}
- DELETE  /api/v1/wishlist/{courseId}
- GET     /api/v1/wishlist
- GET     /api/v1/wishlist/count

### Notes
- Backend remains the single source of truth
- All wishlist operations are idempotent
- Swagger documentation added with minimal, standard annotations

Ready for frontend integration.

Closes #51 
